### PR TITLE
Update openapi.yaml add Submit3DSAuthorization

### DIFF
--- a/openapi/prod/openapi.yaml
+++ b/openapi/prod/openapi.yaml
@@ -51,6 +51,8 @@ paths:
     $ref: ./paths/GetAddCardState.yaml#/paths/GetAddCardState
   /SubmitRandomAmount:
     $ref: ./paths/SubmitRandomAmount.yaml#/paths/SubmitRandomAmount
+  /Submit3DSAuthorization:
+    $ref: ./paths/Submit3DSAuthorization.yaml#/paths/Submit3DSAuthorization
   /Submit3DSAuthorizationV2:
     $ref: ./paths/Submit3DSAuthorizationV2.yaml#/paths/Submit3DSAuthorizationV2
   '/TinkoffPay/terminals/{TerminalKey}/status':


### PR DESCRIPTION
По какой-то причине забыли про метод Submit3DSAuthorization в описании ReDoc. Необходимо добавить файл Submit3DSAuthorization.yaml и скорректировать openapi.yaml

[MCB-2125]